### PR TITLE
Build libcmark locally as a build dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cmark"]
+	path = cmark
+	url = https://github.com/commonmark/cmark.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "doogie"
 version = "0.1.0"
 authors = ["Devin Smith <dsmith@polysync.io>"]
+build = "build.rs"
 
 [dependencies]
 libc = "0.2.0"
@@ -9,3 +10,6 @@ try_from = "0.2.2"
 
 [dev-dependencies]
 proptest = "0.3.3"
+
+[build-dependencies]
+cmake = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+extern crate cmake;
+
+use std::process::Command;
+
+fn main() {
+    // Update cmark submodule if needed
+    Command::new("git")
+        .arg("submodule")
+        .arg("update")
+        .arg("--init")
+        .output()
+        .expect("Failed to run git command, is git installed?");
+
+    // Build cmark
+    let dst = cmake::build("cmark");
+
+    // Inform Cargo where cmark artifacts are located
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join("build").join("src").display());
+    println!("cargo:rustc-link-lib=static=cmark");
+}

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -9,7 +9,6 @@ use super::{CMarkIterPtr, CMarkNodePtr, CapabilityFactory, DelimType, DoogieErro
             NodeRenderer, NodeResource, NodeSetter, NodeTraverser, NodeType, ResourceManager,
             SharedResourceMut, StructuralMutator};
 
-#[link(name = "cmark")]
 extern "C" {
     fn cmark_node_get_literal(node: *mut CMarkNodePtr) -> *const c_char;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@ type SharedResourceMut<T> = Rc<RefCell<T>>;
 pub enum CMarkNodePtr {}
 enum CMarkIterPtr {}
 
-#[link(name = "cmark")]
 extern "C" {
     fn cmark_parse_document(buffer: *const u8, len: size_t, options: c_int) -> *mut CMarkNodePtr;
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -12,7 +12,6 @@ use std::cell::RefCell;
 use super::{CMarkIterPtr, CMarkNodePtr, CapabilityFactory, IterEventType, Node, NodeDestructor,
             NodeFactory, NodeIterator, NodeResource, NodeType, ResourceManager};
 
-#[link(name = "cmark")]
 extern "C" {
     fn cmark_node_free(node: *mut CMarkNodePtr);
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use super::{CMarkIterPtr, CMarkNodePtr, CMarkNodeResource, IterEventType, NodeResource,
             ResourceManager, SharedResourceMut};
 
-#[link(name = "cmark")]
 extern "C" {
     fn cmark_iter_new(node: *mut CMarkNodePtr) -> *mut CMarkIterPtr;
 


### PR DESCRIPTION
Prior to this commit, libcmark was expected to be installed by the user.

This commit migrates that step to a build-dependency of the Cargo package.

The native `libcmark` library is provided as a static library, thus the link attribute
references to the extern functions are removed.

The cmark project is referenced as a git submodule, at `9f8ef820301951f36301c1a40d036cafeaa78619`.

This was validated with `howser`, passing all tests with:
```toml
doogie = { git = "https://github.com/PolySync/doogie", branch = "build-cmark-dependency" }
```