### PR TITLE
Increment version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doogie"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["Devin Smith <dsmith@polysync.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
Prior to this commit, the version was at 0.1.0. The current state of development
adds non-backwards compatible changes to the api so the major version number
should be increased. This commit updates the version number of the crate to
1.0.0.